### PR TITLE
feat: 자재 목록 조회 API 구현

### DIFF
--- a/src/materials/dtos/find-materials.dto.ts
+++ b/src/materials/dtos/find-materials.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsIn, IsNumber, IsOptional, IsString } from 'class-validator';
+import { IsIn, IsNumber, IsOptional, IsString } from 'class-validator';
 import { MaterialCategory } from '../enums/material-category.enum';
 import { Type } from 'class-transformer';
 

--- a/src/materials/dtos/find-materials.dto.ts
+++ b/src/materials/dtos/find-materials.dto.ts
@@ -1,0 +1,23 @@
+import { IsEnum, IsIn, IsNumber, IsOptional, IsString } from 'class-validator';
+import { MaterialCategory } from '../enums/material-category.enum';
+import { Type } from 'class-transformer';
+
+export class FindMaterialsDto {
+  @IsOptional()
+  @IsString()
+  category?: MaterialCategory | undefined;
+
+  @IsOptional()
+  @IsIn(['asc', 'desc', ''])
+  sort?: 'asc' | 'desc' = 'desc';
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  limit?: number = 5;
+}

--- a/src/materials/materials.controller.ts
+++ b/src/materials/materials.controller.ts
@@ -1,6 +1,5 @@
 import { Controller, Get, HttpStatus, Query } from '@nestjs/common';
 import { MaterialsService } from './materials.service';
-import { MaterialCategory } from './enums/material-category.enum';
 import { FindMaterialsDto } from './dtos/find-materials.dto';
 @Controller('materials')
 export class MaterialsController {

--- a/src/materials/materials.controller.ts
+++ b/src/materials/materials.controller.ts
@@ -1,6 +1,29 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, HttpStatus, Query } from '@nestjs/common';
 import { MaterialsService } from './materials.service';
+import { MaterialCategory } from './enums/material-category.enum';
+import { FindMaterialsDto } from './dtos/find-materials.dto';
 @Controller('materials')
 export class MaterialsController {
   constructor(private readonly materialsService: MaterialsService) {}
+
+  @Get()
+  async findMaterials(@Query() query: FindMaterialsDto) {
+    const page = query.page || 1;
+    const limit = query.limit || 5;
+    const sort = query.sort || 'desc';
+    const category = query.category;
+
+    const data = await this.materialsService.findMaterials(
+      sort,
+      page,
+      limit,
+      category,
+    );
+
+    return {
+      statusCode: HttpStatus.OK,
+      message: '주문 목록을 성공적으로 조회하였습니다.',
+      data,
+    };
+  }
 }

--- a/src/materials/materials.service.ts
+++ b/src/materials/materials.service.ts
@@ -8,12 +8,15 @@ import { Material } from './entities/material.entity';
 import { EntityManager, FindManyOptions, Repository } from 'typeorm';
 import { MaterialName } from './enums/material-name.enum';
 import { MaterialCategory } from './enums/material-category.enum';
+import { InjectRedis } from '@nestjs-modules/ioredis';
+import Redis from 'ioredis';
 
 @Injectable()
 export class MaterialsService {
   constructor(
     @InjectRepository(Material)
     private readonly materialRepository: Repository<Material>,
+    @InjectRedis() private readonly redis: Redis,
   ) {}
 
   async decreaseStockQuantityWithManager(
@@ -54,7 +57,20 @@ export class MaterialsService {
     page: number,
     limit: number,
     category: MaterialCategory | undefined,
-  ) {
+  ): Promise<{ data: Material[]; meta: any }> {
+    // 현재 쿼리가 빈번하게 사용되는 '기본 조회'인지 판단
+    const isDefaultQuery =
+      !category && sort === 'desc' && page === 1 && limit === 5;
+
+    // 기본 조회일 경우에만 Redis 캐시를 먼저 확인
+    if (isDefaultQuery) {
+      const cachedData = await this.redis.get('materials:default');
+      // 캐시 데이터가 존재하면 DB 접근 없이 즉시 반환
+      if (cachedData) {
+        return JSON.parse(cachedData) as { data: Material[]; meta: any };
+      }
+    }
+
     // 요청에 따라 where 조건 동적 할당
     const whereCondition: FindManyOptions<Material>['where'] = category
       ? { category }
@@ -74,14 +90,27 @@ export class MaterialsService {
     const [materials, totalCount] =
       await this.materialRepository.findAndCount(findOptions);
 
-    return {
-      data: materials, // 현재 페이지의 데이터
+    // 응답 데이터를 표준화된 형식으로 구성
+    const result = {
+      data: materials,
       meta: {
-        totalCount, // 전체 데이터 개수
+        totalCount,
         page,
         limit,
-        totalPages: Math.ceil(totalCount / limit), // 총 페이지 수 계산
+        totalPages: Math.ceil(totalCount / limit),
       },
     };
+
+    // 현재 쿼리가 '기본 조회'였을 경우, 다음 요청을 위해 Redis에 저장
+    if (isDefaultQuery) {
+      await this.redis.set(
+        'materials:default',
+        JSON.stringify(result),
+        'EX',
+        3600 * 24 * 7,
+      );
+    }
+
+    return result;
   }
 }

--- a/src/materials/materials.service.ts
+++ b/src/materials/materials.service.ts
@@ -5,8 +5,9 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Material } from './entities/material.entity';
-import { EntityManager, Repository } from 'typeorm';
+import { EntityManager, FindManyOptions, Repository } from 'typeorm';
 import { MaterialName } from './enums/material-name.enum';
+import { MaterialCategory } from './enums/material-category.enum';
 
 @Injectable()
 export class MaterialsService {
@@ -46,5 +47,41 @@ export class MaterialsService {
     }
 
     return material;
+  }
+  // 자재 목록 조회
+  async findMaterials(
+    sort: 'asc' | 'desc',
+    page: number,
+    limit: number,
+    category: MaterialCategory | undefined,
+  ) {
+    // 요청에 따라 where 조건 동적 할당
+    const whereCondition: FindManyOptions<Material>['where'] = category
+      ? { category }
+      : {};
+
+    // TypeORM의 findAndCount 메서드에 적용할 옵션 객체
+    const findOptions: FindManyOptions<Material> = {
+      where: whereCondition,
+      order: {
+        createdAt: sort,
+      },
+      skip: (page - 1) * limit, // 페이지 번호와 항목 수 에 따라 건너뛸 데이터 계산
+      take: limit, // 한 페이지에 가져올 데이터 수 지정
+    };
+
+    // 자재 목록 배열과, 전체 개수를 동시에 조회하여 구조분해 할당
+    const [materials, totalCount] =
+      await this.materialRepository.findAndCount(findOptions);
+
+    return {
+      data: materials, // 현재 페이지의 데이터
+      meta: {
+        totalCount, // 전체 데이터 개수
+        page,
+        limit,
+        totalPages: Math.ceil(totalCount / limit), // 총 페이지 수 계산
+      },
+    };
   }
 }

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,9 +1,18 @@
-import { Controller, Post, Body, UseGuards, HttpStatus } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  UseGuards,
+  HttpStatus,
+  Get,
+  Query,
+} from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { UserInfo } from 'src/users/decorators/user-info.decorator';
 import { Payload } from 'src/auth/interfaces/payload.interface';
+import { MaterialCategory } from '@/materials/enums/material-category.enum';
 
 @Controller('orders')
 export class OrdersController {

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -1,12 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { CreateOrderDto } from './dto/create-order.dto';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, FindManyOptions, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Order } from './entities/order.entity';
 import { MaterialsService } from 'src/materials/materials.service';
 import { OrderItemsService } from 'src/order-items/order-items.service';
 import { OrderStatus } from './enums/status.enum';
 import { UsersService } from 'src/users/users.service';
+import { MaterialCategory } from '@/materials/enums/material-category.enum';
+import { find } from 'rxjs';
 
 @Injectable()
 export class OrdersService {


### PR DESCRIPTION
- 카테고리 필터링 기능 추가
- 생성일시 기준 정렬 기능 추가
- 페이지네이션 기능 추가
- findAndCount 메서드로 목록과 전체 개수 동시 반환
- DTO와 ValidationPipe를 활용하여 쿼리 파라미터 유효성검사 및 기본값 설정