### PR TITLE
feat: 관리자 인가 가드 구현

### DIFF
--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -1,0 +1,25 @@
+import { UserRole } from '@/users/enums/user-role.enum';
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class RoleGuard implements CanActivate {
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    const user = request.user;
+
+    if (!user || user.userRole !== UserRole.ADMIN) {
+      throw new ForbiddenException('접근할 수 없는 권한입니다.');
+    }
+
+    return true;
+  }
+}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -55,6 +55,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     if (user.name !== payload.userName) {
       throw new UnauthorizedException('Invalid or expired Token2');
     }
-    return { userId: userId, userName: user.name };
+    return { userId: userId, userName: user.name, userRole: user.role };
   }
 }

--- a/src/materials/materials.controller.ts
+++ b/src/materials/materials.controller.ts
@@ -13,6 +13,7 @@ import { MaterialsService } from './materials.service';
 import { FindMaterialsDto } from './dtos/find-materials.dto';
 import { JwtAuthGuard } from '@/auth/guards/jwt-auth.guard';
 import { UpdateMaterialDto } from './dtos/update-material.dto';
+import { RoleGuard } from '@/auth/guards/roles.guard';
 @Controller('materials')
 export class MaterialsController {
   constructor(private readonly materialsService: MaterialsService) {}
@@ -49,7 +50,7 @@ export class MaterialsController {
     };
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RoleGuard)
   @Patch(':id')
   async updateMaterial(
     @Param('id', ParseIntPipe) id: number,

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -14,6 +14,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { UserRole } from '../enums/user-role.enum';
 
 @Entity()
 export class User {
@@ -45,6 +46,13 @@ export class User {
 
   @Column({ default: 0 })
   point: number;
+
+  @Column({
+    type: 'enum',
+    enum: UserRole,
+    default: UserRole.USER,
+  })
+  role: UserRole;
 
   @IsDate()
   @CreateDateColumn()

--- a/src/users/enums/user-role.enum.ts
+++ b/src/users/enums/user-role.enum.ts
@@ -1,0 +1,4 @@
+export enum UserRole {
+  USER = '일반회원',
+  ADMIN = '관리자',
+}


### PR DESCRIPTION
- 유저의 role 확인
- 유저의 role이 ADMIN이 아닐 경우 `ForbiddenException` 을 반환
- `JwtAuthGuard` 뒤에 `RoleGuard` 적용